### PR TITLE
Additional SSL config options supported

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -51,6 +51,9 @@ default[:vsftpd][:require_ssl_reuse] = false
 default[:vsftpd][:ssl_cert_path] = "/etc/ssl/certs"
 default[:vsftpd][:ssl_private_key_path] = "/etc/ssl/private"
 default[:vsftpd][:ssl_certs_basename] = "ftp.example.com"
+default[:vsftpd][:force_local_logins_ssl] = true
+default[:vsftpd][:force_local_data_ssl] = true
+
 # Logging options
 default[:vsftpd][:xferlog_enable] = true
 default[:vsftpd][:xferlog_file] = "/var/log/vsftpd.log"

--- a/templates/default/vsftpd.conf.erb
+++ b/templates/default/vsftpd.conf.erb
@@ -51,3 +51,5 @@ virtual_use_local_privs=<%= node[:vsftpd][:virtual_use_local_privs] ? 'YES' : 'N
 <% if node[:vsftpd][:deny_file].count >= 1 %>
 deny_file={<%= node[:vsftpd][:deny_file].join(",") %>}
 <% end %>
+force_local_logins_ssl=<%= node[:vsftpd][:force_local_logins_ssl] ? 'YES' : 'NO' %>
+force_local_data_ssl=<%= node[:vsftpd][:force_local_logins_ssl] ? 'YES' : 'NO' %>


### PR DESCRIPTION
Add config support for force_local_logins_ssl and force_local_logins_ssl, both defaulting to 'YES' as per the default vsftpd spec.
